### PR TITLE
Enable Gnome 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Disable all GNOME built-in gestures. Useful for kiosks and touch screen apps.",
   "uuid": "disable-gestures-2021@verycrazydog.gmail.com",
   "shell-version": [
-    "3.36", "40.0"
+    "3.36", "40", "41"
   ],
   "url": "https://github.com/VeryCrazyDog/gnome-disable-gestures"
 }


### PR DESCRIPTION
This extension works fine in Gnome 41 too, and it is very useful for people playing with my [vmpk](https://github.com/pedrolcl/vmpk) virtual piano!